### PR TITLE
docs: disable markdown link check for badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # twinsphere Documentation
 
+<!-- markdown-link-check-disable -->
+
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+
+<!-- markdown-link-check-enable -->
 
 Documentation for the twinsphere toolsuite.
 


### PR DESCRIPTION
When running the link check, the badges result in a 404 error. Disable the link check for these files.