### PR TITLE
ci: insufficient glob pattern for linter

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -52,6 +52,12 @@ jobs:
 
     - name: Lint markdown files
       uses: DavidAnson/markdownlint-cli2-action@v20
+      with:
+        globs: |
+          CONTRIBUTING.md
+          README.md
+          docs/*.md
+          docs/**/*.md
 
     - name: Validate link targets
       uses: tcort/github-action-markdown-link-check@v1


### PR DESCRIPTION
The linter is called with a glob pattern that does not capture all available markdown files, thus preventing it from performing its action properly. Thus we adjust the globs so that all files are found.