### PR TITLE
fix(tam): remove double entry in changelog

### DIFF
--- a/docs/typed-aas-metamodels-release_notes.md
+++ b/docs/typed-aas-metamodels-release_notes.md
@@ -28,14 +28,6 @@ The twinsphere.TypedAasMetamodels library follows [semantic versioning](https://
 - **[Bugfix]** Add missing constraint on Path types
 - **[Bugfix]** Fix null dereference in validation of Handover Documentation 1.2
 
-- **[TAM]** Update to most recent specification versions for several submodels
-    - Contact Informations 1.0
-    - Technical Data 2.0
-    - Handover Documentation 2.0
-    - Hierarchical Structures enabling Bill of Materials 1.1
-- **[Bugfix]** Packaging and conversion now ensures that file paths/values are properly percent encoded in conformity
-  with RFC2396.
-
 ## twinsphere.TypedAasMetamodels 1.1.4
 
 *Released on 20-Nov-2025*.


### PR DESCRIPTION
The changelog for TAM contains a double entry. Remove it.