### PR TITLE
feat(tam-conversion): fromstring conversion and namespace compatibility

### DIFF
--- a/docs/typed-aas-metamodels-overview.md
+++ b/docs/typed-aas-metamodels-overview.md
@@ -428,7 +428,7 @@ catch (SubmodelConversionException conversionException)
 string submodelJson;
 string submodelXml;
 
-// 1b. convert Json to typed representation
+// 1b. convert JSON to typed representation
 DigitalNameplate digitalNameplate;
 try
 {
@@ -450,7 +450,7 @@ catch (SubmodelConversionException conversionException)
     Console.Error($"Failed to convert from Xml: {conversionException}");
 }
 
-// while converting from XML both Namespaces `https://admin-shell.io/aas/3/1` 
+// while converting from XML both Namespaces `https://admin-shell.io/aas/3/1`
 // and `https://admin-shell.io/aas/3/0` are viable
 
 // 2. perform operations on the Digital Nameplate
@@ -470,12 +470,17 @@ catch (SubmodelConversionException conversionException)
 ```
 
 !!! note
-    `FromMetamodel(), FromJsonString() and FromXmlString()` will use the validation mechanism to check whether the submodel is a valid instance of its
-    SMT. If it is not, it will throw a `SubmodelConversionException` with the encountered errors.
+    `FromMetamodel()`, `FromJsonString()`, and `FromXmlString()` will use the validation mechanism
+    to check whether the submodel is a valid instance of its SMT.
+    If it is not, it will throw a `SubmodelConversionException` with the encountered errors.
 
-For Convenience you can also use `twinsphere.TypedAasMetamodels.Common.Conversion.FromStringConversion` to convert 
-serialized XML or JSON to Metamodel or Typed Models.
-Also you can create an XML Reader that converts the 3.0 Namespace to 3.1.
+`FromJsonString()` and `FromXmlString()` use `twinsphere.TypedAasMetamodels.Common.Conversion.FromStringConversion`
+to convert serialized XML or JSON to Metamodel and Typed Models:
+`TMeta MetaModelFromXml<TMeta>(string xmlString)` converts to the given Metamodel from Xml.
+`TMeta MetaModelFromJson<TMeta>(string jsonString)` converts to the given Metamodel from JSON.
+`TType TypedModelFromXml<TType, TMeta>(string xmlString)` converts to the given Typedmodel from Xml.
+`TType TypedModelFromJson<TType, TMeta>(string jsonString)` converts to the given Typedmodel from JSON.
+`XmlReader ConvertFrom30To31(XmlReader reader)` creates an XmlReader with corrected 3.1 Xml Namespace.
 
 ## Additional Features
 

--- a/docs/typed-aas-metamodels-overview.md
+++ b/docs/typed-aas-metamodels-overview.md
@@ -404,7 +404,7 @@ else
 The twinsphere.TypedAasMetamodels library provides the means to convert between ([valid](typed-aas-metamodels-validation.md))
 models in the generic meta model representation and the typed submodel, and vice versa.
 
-To this end, submodels implement `FromMetamodel()` and `ToMetamodel()`:
+To this end, submodels implement `FromMetamodel()` and `ToMetamodel()` as well as `FromXmlString` and `FromJsonString`:
 
 ```csharp
 using AasCore.Aas3_0;
@@ -413,7 +413,7 @@ using twinsphere.TypedAasMetamodels.Types.Submodels.DigitalNameplate.V2_0;
 Aas3_0.ISubmodel digitalNameplateMetamodel;
 // ... load a Digital Nameplate from some source, e.g., from a repository.
 
-// 1. convert to its typed representation
+// 1a. convert a Metamodel to its typed representation
 DigitalNameplate digitalNameplate;
 try
 {
@@ -423,6 +423,35 @@ catch (SubmodelConversionException conversionException)
 {
     Console.Error($"Failed to convert from erroneous submodel: {conversionException}");
 }
+
+// or load a string representation in JSON or XML format
+string submodelJson;
+string submodelXml;
+
+// 1b. convert Json to typed representation
+DigitalNameplate digitalNameplate;
+try
+{
+    digitalNameplate = DigitalNameplate.FromJsonString(submodelJson);
+}
+catch (SubmodelConversionException conversionException)
+{
+    Console.Error($"Failed to convert from Json: {conversionException}");
+}
+
+// 1c. convert Xml to typed representation
+DigitalNameplate digitalNameplate;
+try
+{
+    digitalNameplate = DigitalNameplate.FromXmlString(submodelXml);
+}
+catch (SubmodelConversionException conversionException)
+{
+    Console.Error($"Failed to convert from Xml: {conversionException}");
+}
+
+// while converting from XML both Namespaces `https://admin-shell.io/aas/3/1` 
+// and `https://admin-shell.io/aas/3/0` are viable
 
 // 2. perform operations on the Digital Nameplate
 digitalNameplate.SoftwareVersion = "1.0.0".ToMultiLanguageString("en");
@@ -441,8 +470,12 @@ catch (SubmodelConversionException conversionException)
 ```
 
 !!! note
-    `FromMetamodel()` will use the validation mechanism to check whether the submodel is a valid instance of its
+    `FromMetamodel(), FromJsonString() and FromXmlString()` will use the validation mechanism to check whether the submodel is a valid instance of its
     SMT. If it is not, it will throw a `SubmodelConversionException` with the encountered errors.
+
+For Convenience you can also use `twinsphere.TypedAasMetamodels.Common.Conversion.FromStringConversion` to convert 
+serialized XML or JSON to Metamodel or Typed Models.
+Also you can create an XML Reader that converts the 3.0 Namespace to 3.1.
 
 ## Additional Features
 


### PR DESCRIPTION
Adds documentation for the `FromString` interface, which enabled to Convert from XML and Json to Typed Models and also brings a helper class to convert from XML and Json to Metamodel and Typed Model as well as converting an 3.0 Namespace to 3.1 in XML